### PR TITLE
Add WM_CLASS attribute

### DIFF
--- a/dispass/gui.py
+++ b/dispass/gui.py
@@ -30,14 +30,14 @@ class GUI(Frame):
     fontsize = 10
     '''Default fontsize (10 pt.)'''
 
-    def __init__(self, master=None):
+    def __init__(self):
         '''Initialize GUI object, create the widgets and start mainloop
 
         Try to import Tkinter and tkMessageBox. If that fails, show a help
         message with quick instructions on installing Tkinter.
         '''
 
-        Frame.__init__(self, master)
+        Frame.__init__(self, Tk(className='dispass'))
         self.master.title(versionStr)
         self.grid()
         self.createWidgets()


### PR DESCRIPTION
This sets the window class name to Dispass and the window instance
name to dispass.

It used to default to `Tk/tk`, but that makes for very difficult rule matching in window manangers such as `herbstluftwm` and `spectrewm`.

I tried to get it to `DisPass/dispass`, but setting `className` to `DisPass` resulted in `Dispass/disPass` and setting it to `DisPass/dispass` has the same effect as just setting `dispass`.
