### PR TITLE
Allow each option to be overridden individually

### DIFF
--- a/dispass/commands/generate.py
+++ b/dispass/commands/generate.py
@@ -54,25 +54,21 @@ class Command(CommandBase):
             print self.usage
             return 1
 
-        algo = self.settings.algorithm
-        length = self.settings.passphrase_length
-        seqno = self.settings.sequence_number
+        algo = None
+        length = None
+        seqno = None
 
-        override = False
         if self.flags['algo']:
             if self.flags['algo'] in algorithms:
                 algo = self.flags['algo']
-            override = True
         if self.flags['length']:
             try:
                 length = int(self.flags['length'])
             except ValueError:
                 print 'Error: length argument must be a number'
                 return 1
-            override = True
         if self.flags['seqno']:
             seqno = self.flags['seqno']
-            override = True
 
         console = CLI(lf)
         console.verifyPassword = self.flags['verify']
@@ -84,10 +80,15 @@ class Command(CommandBase):
 
         for arg in self.args:
             labeltup = lf.labeltup(arg)
-            if labeltup and not override:
-                console.generate(password, labeltup)
+            if labeltup:
+                console.generate(password, (arg, length or labeltup[1],
+                                            algo or labeltup[2],
+                                            seqno or labeltup[3]))
             else:
-                console.generate(password, (arg, length, algo, seqno))
+                console.generate(password, (
+                    arg, length or self.settings.passphrase_length,
+                    algo or self.settings.algorithm,
+                    seqno or self.settings.sequence_number))
         del password
 
         if self.flags['stdout']:


### PR DESCRIPTION
# The problem:

I have in my labelfile:

```
test algorithm=dispass2
```

I call dispass:

```
# dispass generate -o test
Password:
test                                               Mzg2ZGFiYjIxZDFhMjFiMjRkNjUyNW
```

All is well. Then I try:

```
# dispass generate -o -l 29 test
Password:
test                                               NjIzYzkyZDhjM2U4MGE2OTYzNTk5Z
```

Oops! that should have produced:

```
test                                               Mzg2ZGFiYjIxZDFhMjFiMjRkNjUyN
```

both cases used the password `testtest`.
# The cause:

In the `generate.py` file there is a local override switch which gets activated whenever one of the options is specified on the command line, in this case the `-l` switch. This causes the settings in the labelfile to be completely ignored and the defaults to be used and overridden instead.
# The solution:

Instead of checking whether an override should happen, assume that when the user specifies an option on the command line they will only want that option to be overridden and allow it to override either the settings from the labelfile or the defaults where applicable.
