### PR TITLE
Make the gui command listen to the -f switch

### DIFF
--- a/dispass/commands/gui.py
+++ b/dispass/commands/gui.py
@@ -13,6 +13,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 from dispass.common import CommandBase
+from dispass.filehandler import Filehandler
 
 
 class Command(CommandBase):
@@ -27,9 +28,15 @@ class Command(CommandBase):
             print self.usage
             return
 
+        if self.parentFlags['file']:
+            lf = Filehandler(self.settings,
+                             file_location=self.parentFlags['file'])
+        else:
+            lf = Filehandler(self.settings)
+
         try:
             from dispass.gui import GUI
-            g = GUI(self.settings)
+            g = GUI(self.settings, lf)
             g.mainloop()
         except ImportError:
             print ('Could not find Tkinter, this is a package needed '

--- a/dispass/gui.py
+++ b/dispass/gui.py
@@ -34,7 +34,6 @@ import ttk
 
 import algos
 from dispass import versionStr as dispass_version
-from filehandler import Filehandler
 
 versionStr = 'g%s' % dispass_version
 
@@ -48,7 +47,7 @@ class GUI(Frame):
     fontsize = 10
     '''Default fontsize (10 pt.)'''
 
-    def __init__(self, settings):
+    def __init__(self, settings, filehandler):
         '''Initialize GUI object, create the widgets and start mainloop
 
         Try to import Tkinter and tkMessageBox. If that fails, show a help
@@ -56,8 +55,7 @@ class GUI(Frame):
         '''
 
         self.settings = settings
-        self.labelspecs = {l[0]: l[1:] for l in
-                           Filehandler(self.settings).labelfile}
+        self.labelspecs = {l[0]: l[1:] for l in filehandler.labelfile}
 
         Frame.__init__(self, Tk(className='dispass'))
         self.lengthVar = IntVar()


### PR DESCRIPTION
Pass a correctly created `Filehandler' object to the`GUI' object
instead of making it responsible for creating its own.

This fixes issue #22
