### PR TITLE
Fix gdispass script

### DIFF
--- a/scripts/gdispass
+++ b/scripts/gdispass
@@ -19,10 +19,12 @@ import exceptions
 
 from dispass.gui import GUI
 from dispass.dispass import Settings
+from dispass.filehandler import Filehandler
 
 if __name__ == '__main__':
     try:
-        gui = GUI(Settings())
+        settings = Settings()
+        gui = GUI(settings, Filehandler(settings))
         gui.mainloop()
     except ImportError:
         print ('Could not find Tkinter, this is a package needed for using\n'


### PR DESCRIPTION
When trying to start `gdispass` prior to this change I get the following output:

``` pytb
Traceback (most recent call last):
  File "/usr/bin/gdispass", line 25, in <module>
    gui = GUI(Settings())
TypeError: __init__() takes exactly 3 arguments (2 given)
```

I didn't look very thoroughly at how the `GUI` class is instantiated using the `dispass gui` command, so I may be missing some subleties here.
