### PR TITLE
Properly align list command for small labels

### DIFF
--- a/dispass/filehandler.py
+++ b/dispass/filehandler.py
@@ -293,12 +293,17 @@ class Filehandler:
                                   'y' if label[4] else 'n'))
         else:
             divlen = self.longest_label
+
             if not divlen:
                 return
+
+            divtitle = 'Label'
+            divlen = max(divlen, len(divtitle))
+
             print('+-{spacer:{fill}}-+--------+----------+--------+---+\n'
                   '| {title:{fill}} | Length | Algo     | Number | X |\n'
                   '+-{spacer:{fill}}-+--------+----------+--------+---+'
-                  .format(spacer='-' * divlen, title='Label', fill=divlen))
+                  .format(spacer='-' * divlen, title=divtitle, fill=divlen))
 
             for label in self.labelfile:
                 if all_ or not label[4]:


### PR DESCRIPTION
The minimum width of the “Label” column is the width of it’s title.

I noticed this problem working on my last two pull requests.

```
$ dispass -f testlabels add foo
$ dispass -f testlabels list
+-----+--------+----------+--------+---+
| Label | Length | Algo     | Number | X |
+-----+--------+----------+--------+---+
| foo |     30 | dispass1 |      1 | n |
+-----+--------+----------+--------+---+
```