### PR TITLE
Fix the generate command

### DIFF
--- a/dispass/commands/generate.py
+++ b/dispass/commands/generate.py
@@ -95,12 +95,14 @@ class Command(CommandBase):
             if labeltup:
                 console.generate(password, (arg, length or labeltup[1],
                                             algo or labeltup[2],
-                                            seqno or labeltup[3]))
+                                            seqno or labeltup[3],
+                                            False))
             else:
                 console.generate(password, (
                     arg, length or settings.passphrase_length,
                     algo or settings.algorithm,
-                    seqno or settings.sequence_number))
+                    seqno or settings.sequence_number,
+                    False))
         del password
 
         if self.flags['stdout']:


### PR DESCRIPTION
Just like the ‘-g’ switch for the ‘add’ command before it, the
‘generate’ command wasn’t updated to include a full tuple required by
the ‘generate’ method.

I noticed this today when I updated my `python2-dispass-git` package and couldn't generate any passphrases anymore. Luckily I still had a package from 2014 lying around to downgrade.