### PR TITLE
Explain add in steps, expand on verify flag

### DIFF
--- a/docs/en/quick-start.rst
+++ b/docs/en/quick-start.rst
@@ -24,20 +24,21 @@ Using DisPass for the first time
 
 For this example we will create a passphrase to use for a google account.
 
-Create and save a label ``google`` to the labelfile:
+1. Create and save a label ``google`` to the labelfile:
 
-.. code:: console
+   .. code:: console
 
-    dispass add google
+       dispass add google
 
-Generate the passphrase for the first time. Since you will need to
-register the passphrase with google we pass the ``--verify`` flag
-or simply ``-v`` to avoid typing errors in the input password while
-creating the resulting passphrase for the first time:
+2. Generate the passphrase for the first time. Since you will need to
+   register the passphrase with google we pass the ``--verify`` flag
+   or simply ``-v`` so DisPass asks us to verify the password and we
+   can avoid typing errors in the input password while creating the
+   resulting passphrase for the first time:
 
-.. code:: console
+   .. code:: console
 
-    dispass generate --verify google
+       dispass generate --verify google
 
 
 Mini screencast


### PR DESCRIPTION
- The “Using DisPass for the first time” section in the Quick start
  chapter seemed phrased as steps, but it was unclear they were steps.
  This made the start of the second step a bit awkward.

- It was never explained what the ‘--verify’ flag actually does in the
  second step of the “Using DisPass for the first time” section.