### PR TITLE
Add desktop file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+DESKTOP_PATH    = $(DESTDIR)/usr/share/applications
+ICON_PATH       = $(DESTDIR)/usr/share/icons/hicolor
 MAN_PATH		= $(DESTDIR)/usr/share/man/man1
 ZSH_SITE_FUNCS_PATH	= $(DESTDIR)/usr/share/zsh/site-functions
 PYTHON_EXEC		= python2
@@ -45,8 +47,13 @@ dist: rm_pyc
 install: dist
 	$(PIP_EXEC) install --root $(DESTDIR) --upgrade dist/DisPass-$(VERSION).tar.gz
 	gzip -c dispass.1 > dispass.1.gz
-	mv dispass.1.gz $(MAN_PATH)
-	cp zsh/_dispass $(ZSH_SITE_FUNCS_PATH)
+	install -Dm644 dispass.1.gz $(MAN_PATH)/dispass.1.gz
+	install -Dm644 zsh/_dispass $(ZSH_SITE_FUNCS_PATH)/_dispass
+	install -Dm644 etc/dispass.desktop $(DESKTOP_PATH)/dispass.desktop
+	for size in 24 32 64 128 256 512; do \
+		install -Dm644 "logo/logo$${size}.png" \
+		"$(ICON_PATH)/$${size}x$${size}/apps/dispass.png"; \
+	done
 	make clean
 
 uninstall: clean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MAN_PATH		= /usr/share/man/man1
-ZSH_SITE_FUNCS_PATH	= /usr/share/zsh/site-functions
+MAN_PATH		= $(DESTDIR)/usr/share/man/man1
+ZSH_SITE_FUNCS_PATH	= $(DESTDIR)/usr/share/zsh/site-functions
 PYTHON_EXEC		= python2
 PIP_EXEC		= pip2
 
@@ -43,7 +43,7 @@ dist: rm_pyc
 	$(PYTHON_EXEC) setup.py sdist
 
 install: dist
-	$(PIP_EXEC) install --upgrade dist/DisPass-$(VERSION).tar.gz
+	$(PIP_EXEC) install --root $(DESTDIR) --upgrade dist/DisPass-$(VERSION).tar.gz
 	gzip -c dispass.1 > dispass.1.gz
 	mv dispass.1.gz $(MAN_PATH)
 	cp zsh/_dispass $(ZSH_SITE_FUNCS_PATH)

--- a/etc/dispass.desktop
+++ b/etc/dispass.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=DisPass
+GenericNAme=Passphrase Generator
+Comment=Generate passphrases
+Exec=gdispass
+Type=Application
+StartupWMClass=Dispass
+Icon=dispass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pycommand==0.3.0
+wheel==0.29.0


### PR DESCRIPTION
This also adds the `$DESTDIR` variable to the Makefile and installs the appropriate logo files to the hicolor icon theme so they can be found by the desktop environment parsing the desktop file.

I changed some `mv` and `cp` calls in the Makefile to `install` because my test (`make install DESTDIR=$(realpath dispass-test/)`) ran into errors of non-existent directories.

I didn't know where to put the desktop file, so I added an `etc/` directory.