### PR TITLE
Explain tk install in docs, reference in errors

### DIFF
--- a/dispass/commands/gui.py
+++ b/dispass/commands/gui.py
@@ -48,14 +48,7 @@ class Command(CommandBase):
         except ImportError:
             print('Could not find Tkinter, this is a package needed '
                   'for using\n' 'the graphical version of dispass.\n'
-                  'To install, search for a python-tk package for'
-                  ' your OS.\n'
-                  'Debian / Ubuntu\t\t$ sudo apt-get install '
-                  'python-tk\n'
-                  'OpenBSD        \t\t# pkg_add -i python-tk\n'
                   '\n'
-                  'Archlinux:\n'
-                  '  The Tkinter library is included in the python2\n'
-                  '  package, so just ensure that the tk package is\n'
-                  '  installed: sudo pacman -S tk')
+                  'For installation instructions, please see the\n'
+                  '"Using gdispass" chapter of the documentation.')
             return 2

--- a/docs/en/using-gdispass.rst
+++ b/docs/en/using-gdispass.rst
@@ -1,6 +1,26 @@
 Using gdispass
 ==============
 
+Before you start using ``gDispass``, make sure that the Tkinter
+library is available. Here are some instructions to help you along:
+
+Debian / Ubuntu
+   Make sure the ``python-tk`` package is installed::
+
+      sudo apt-get install python-tk
+
+OpenBSD
+   Make sure the ``python-tk`` package is installed::
+
+      pkg_add -i python-tk
+
+Archlinux
+   The Tkinter Python library is included in the ``python2`` package,
+   to make it work you need to be sure the ``tk`` package is
+   installed::
+
+      sudo pacman -S tk
+
 You can start using gDisPass by running the ``gdispass`` executable.
 Fill in a name for the label that you can easily remember.
 

--- a/scripts/gdispass
+++ b/scripts/gdispass
@@ -31,13 +31,8 @@ if __name__ == '__main__':
     except ImportError:
         print ('Could not find Tkinter, this is a package needed for using\n'
                'the graphical version of dispass.\n'
-               'To install, search for a python-tk package for your OS.\n'
-               'Debian / Ubuntu\t\t$ sudo apt-get install python-tk\n'
-               'OpenBSD        \t\t# pkg_add -i python-tk\n'
                '\n'
-               'Archlinux:\n'
-               '  The Tkinter library is included in the python2\n'
-               '  package, so just ensure that the tk package is\n'
-               '  installed: sudo pacman -S tk')
+               'For installation instructions, please see the\n'
+               '"Using gdispass" chapter of the documentation.')
     except exceptions.KeyboardInterrupt:
         print ('\nOk, bye')


### PR DESCRIPTION
Instead of explaining how to install the “python-tk” or “tk” packages in
the error message, reference the documentation where it is explained.