### PR TITLE
Change supported python to python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.6"
 script: nosetests -v
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
+  - "3.4"
+  - "3.5"
   - "3.6"
 script: nosetests -v
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ ICON_PATH		= $(DESTDIR)/usr/share/icons/hicolor
 MAN_PATH		= $(DESTDIR)/usr/share/man/man1
 INFO_PATH		= $(DESTDIR)/usr/share/info
 ZSH_SITE_FUNCS_PATH	= $(DESTDIR)/usr/share/zsh/site-functions
-PYTHON_EXEC		= python2
-PIP_EXEC		= pip2
+PYTHON_EXEC		= python
+PIP_EXEC		= pip
 
 sinclude config.mk
 

--- a/bin/dispass
+++ b/bin/dispass
@@ -16,8 +16,6 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-import exceptions
-
 import pycommand
 
 from dispass.dispass import DispassCommand
@@ -25,5 +23,5 @@ from dispass.dispass import DispassCommand
 if __name__ == '__main__':
     try:
         pycommand.run_and_exit(DispassCommand)
-    except exceptions.KeyboardInterrupt:
+    except KeyboardInterrupt:
         print ('\nOk, bye')

--- a/bin/gdispass
+++ b/bin/gdispass
@@ -16,8 +16,6 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-import exceptions
-
 from dispass.dispass import Settings
 from dispass.filehandler import Filehandler
 
@@ -34,5 +32,5 @@ if __name__ == '__main__':
                '\n'
                'For installation instructions, please see the\n'
                '"Using gdispass" chapter of the documentation.')
-    except exceptions.KeyboardInterrupt:
+    except KeyboardInterrupt:
         print ('\nOk, bye')

--- a/dispass/__init__.py
+++ b/dispass/__init__.py
@@ -1,4 +1,4 @@
 '''Multi-platform console/gui passphrase generator'''
 
-from dispass import __docformat__, __author__, __copyright__
-from dispass import __version_info__, __version__
+from dispass.dispass import __docformat__, __author__, __copyright__
+from dispass.dispass import __version_info__, __version__

--- a/dispass/algos.py
+++ b/dispass/algos.py
@@ -70,10 +70,11 @@ class Dispass1:
         '''
 
         sha = hashlib.sha512()
-        sha.update(str(label) + str(password))
-        r = base64.b64encode(sha.hexdigest(), '49').replace('=', '')
+        sha.update(label.encode('utf-8') + password.encode('utf-8'))
+        r = base64.b64encode(sha.hexdigest().encode('utf-8'), b'49') \
+                  .replace(b'=', b'')
 
-        return str(r[:length])
+        return r[:length].decode()
 
 
 class Dispass2:
@@ -108,10 +109,13 @@ class Dispass2:
         '''
 
         sha = hashlib.sha512()
-        sha.update(str(label) + str(seqno) + str(password))
-        r = base64.b64encode(sha.hexdigest(), '49').replace('=', '')
+        sha.update(label.encode('utf-8') +
+                   str(seqno).encode('utf-8') +
+                   password.encode('utf-8'))
+        r = base64.b64encode(sha.hexdigest().encode('utf-8'), b'49') \
+                  .replace(b'=', b'')
 
-        return str(r[:length])
+        return r[:length].decode()
 
 
 if __name__ == '__main__':

--- a/dispass/cli.py
+++ b/dispass/cli.py
@@ -132,7 +132,7 @@ class CLI:
             stdscr.addstr(1, 0, "Your passphrase(s)", curses.A_BOLD)
 
             j = 3
-            for label, passphrase in self.passphrases.iteritems():
+            for label, passphrase in self.passphrases.items():
                 stdscr.addstr(j,  0, label, curses.A_BOLD)
                 stdscr.addstr(j, divlen, passphrase)
                 j += 1
@@ -149,7 +149,7 @@ class CLI:
             curses.echo()
             curses.endwin()
         else:
-            for label, passphrase in self.passphrases.iteritems():
+            for label, passphrase in self.passphrases.items():
                 if self.scriptableIO:
                     print('{:50} {}'.format(label[:50], passphrase))
                 else:

--- a/dispass/cli.py
+++ b/dispass/cli.py
@@ -15,8 +15,8 @@
 
 import getpass
 
-from algos import algoObject
-from dispass import versionStr
+from dispass.algos import algoObject
+from dispass.dispass import versionStr
 
 try:
     import curses

--- a/dispass/commands/disable.py
+++ b/dispass/commands/disable.py
@@ -41,7 +41,7 @@ class Command(CommandBase):
         '''Parse the arguments and disable using `Filehandler.disable`.'''
 
         if not len(self.args) == 1 or self.flags['help']:
-            print self.usage
+            print(self.usage)
             return
 
         labelname = self.args[0]

--- a/dispass/commands/enable.py
+++ b/dispass/commands/enable.py
@@ -41,7 +41,7 @@ class Command(CommandBase):
         '''Parse the arguments and enable using `Filehandler.disable`.'''
 
         if not len(self.args) == 1 or self.flags['help']:
-            print self.usage
+            print(self.usage)
             return
 
         labelname = self.args[0]

--- a/dispass/commands/help.py
+++ b/dispass/commands/help.py
@@ -15,7 +15,6 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-import exceptions
 import importlib
 
 from pycommand import CommandBase
@@ -43,7 +42,7 @@ class Command(CommandBase):
                 print('error: command {cmd} does not exist'
                       .format(cmd=self.args[0]))
                 return 1
-            except exceptions.KeyboardInterrupt:
+            except KeyboardInterrupt:
                 print('\nOk, bye')
                 return 1
 

--- a/dispass/commands/update.py
+++ b/dispass/commands/update.py
@@ -44,7 +44,7 @@ class Command(CommandBase):
         '''Parse the arguments and update them using `FileHandler.update`.'''
 
         if not len(self.args) == 2 or self.flags['help']:
-            print self.usage
+            print(self.usage)
             return
 
         labelname = self.args[0]

--- a/dispass/dispass.py
+++ b/dispass/dispass.py
@@ -106,30 +106,30 @@ class DispassCommand(pycommand.CommandBase):
 
         '''
 
-        import commands.add
-        import commands.disable
-        import commands.enable
-        import commands.generate
-        import commands.gui
-        import commands.help
-        import commands.increment
-        import commands.list
-        import commands.remove
-        import commands.update
-        import commands.version
+        import dispass.commands.add
+        import dispass.commands.disable
+        import dispass.commands.enable
+        import dispass.commands.generate
+        import dispass.commands.gui
+        import dispass.commands.help
+        import dispass.commands.increment
+        import dispass.commands.list
+        import dispass.commands.remove
+        import dispass.commands.update
+        import dispass.commands.version
 
         self.commands = {
-            'add': commands.add.Command,
-            'disable': commands.disable.Command,
-            'enable': commands.enable.Command,
-            'generate': commands.generate.Command,
-            'gui': commands.gui.Command,
-            'help': commands.help.Command,
-            'increment': commands.increment.Command,
-            'list': commands.list.Command,
-            'remove': commands.remove.Command,
-            'update': commands.update.Command,
-            'version': commands.version.Command,
+            'add': dispass.commands.add.Command,
+            'disable': dispass.commands.disable.Command,
+            'enable': dispass.commands.enable.Command,
+            'generate': dispass.commands.generate.Command,
+            'gui': dispass.commands.gui.Command,
+            'help': dispass.commands.help.Command,
+            'increment': dispass.commands.increment.Command,
+            'list': dispass.commands.list.Command,
+            'remove': dispass.commands.remove.Command,
+            'update': dispass.commands.update.Command,
+            'version': dispass.commands.version.Command,
         }
 
         if self.flags['help']:

--- a/dispass/filehandler.py
+++ b/dispass/filehandler.py
@@ -329,7 +329,7 @@ class Filehandler:
 
         print('error: could not load labelfile at "{loc}"'
               .format(loc=self.file_location))
-        inp = raw_input('Do you want to create it? Y/n ')
+        inp = input('Do you want to create it? Y/n ')
 
         if inp == '' or inp[0].lower() == 'y':
             # create directories for file_location if they don't exist

--- a/dispass/filehandler.py
+++ b/dispass/filehandler.py
@@ -19,7 +19,7 @@ import datetime
 import os
 from os.path import expanduser, exists
 
-from dispass import __version__
+from dispass.dispass import __version__
 
 
 class Filehandler:

--- a/dispass/gui.py
+++ b/dispass/gui.py
@@ -13,7 +13,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-from Tkinter import (
+from tkinter import (
     Button,
     Checkbutton,
     Entry,
@@ -30,8 +30,8 @@ from Tkinter import (
     N, E, S, W,
 )
 import sys
-import tkMessageBox
-import ttk
+import tkinter.messagebox as tkMessageBox
+import tkinter.ttk as ttk
 
 import dispass.algos as algos
 from dispass.dispass import versionStr as dispass_version

--- a/dispass/gui.py
+++ b/dispass/gui.py
@@ -247,7 +247,7 @@ class GUI(Frame):
         self.algorithm = ttk.Combobox(self, width=27, font=self.getFont(),
                                       values=algos.algorithms)
         sequence = Spinbox(self, width=3, font=self.getFont, from_=1,
-                           to=sys.maxint, textvariable=self.sequenceVar)
+                           to=sys.maxsize, textvariable=self.sequenceVar)
         genbutton = Button(self, text="Generate password",
                            font=self.getFont(), command=self.validateAndShow,
                            default="active")

--- a/dispass/gui.py
+++ b/dispass/gui.py
@@ -33,8 +33,8 @@ import sys
 import tkMessageBox
 import ttk
 
-import algos
-from dispass import versionStr as dispass_version
+import dispass.algos as algos
+from dispass.dispass import versionStr as dispass_version
 
 versionStr = 'g%s' % dispass_version
 

--- a/dispass/interactive_editor.py
+++ b/dispass/interactive_editor.py
@@ -43,7 +43,7 @@ class InteractiveEditor:
 
     def prompt(self):
         try:
-            inp = raw_input('\n> ').split()
+            inp = input('\n> ').split()
             if not inp:
                 print('No menu option given')
                 self.prompt()
@@ -79,7 +79,7 @@ class InteractiveEditor:
         '''
         while True:
             try:
-                return raw_input('Label: ').split()[0]
+                return input('Label: ').split()[0]
             except IndexError:
                 print('label cannot be empty - please try again')
                 continue
@@ -90,7 +90,7 @@ class InteractiveEditor:
         while True:
             try:
                 length = (
-                    raw_input('Length [press enter for default "{len}"]: '
+                    input('Length [press enter for default "{len}"]: '
                               .format(len=self.settings.passphrase_length))
                     .split()[0])
             except IndexError:
@@ -120,7 +120,7 @@ class InteractiveEditor:
                         choices += ' [default]'
                     print(choices)
                     i += 1
-                choice = (raw_input('Algorithm [press enter for default]: ')
+                choice = (input('Algorithm [press enter for default]: ')
                           .split()[0])
             except IndexError:
                 algo = self.settings.algorithm
@@ -150,7 +150,7 @@ class InteractiveEditor:
             while True:
                 try:
                     seqno = (
-                        raw_input(
+                        input(
                             'Sequence number [press enter for default'
                             ' "{seqno}"]: '.format(seqno=default_seqno))
                         .split()[0])

--- a/dispass/interactive_editor.py
+++ b/dispass/interactive_editor.py
@@ -15,7 +15,7 @@
 
 import sys
 
-import algos
+import dispass.algos as algos
 
 
 class InteractiveEditor:


### PR DESCRIPTION
These commits should make DisPass work on Python 3 while dropping support for Python 2. This might resolve #28, depending on what you meant by optimize.

I've tested a fair amount, but haven't tried using it in real life yet, I'm going to start that now.

Let me know what you think!