### PR TITLE
Clean up ncurses after exception

### DIFF
--- a/dispass/cli.py
+++ b/dispass/cli.py
@@ -139,15 +139,16 @@ class CLI:
             stdscr.refresh()
             curses.curs_set(0)
 
-            while True:
-                c = stdscr.getch()
-                if c == ord('q'):
-                    stdscr.erase()
-                    break
-
-            curses.nocbreak()
-            curses.echo()
-            curses.endwin()
+            try:
+                while True:
+                    c = stdscr.getch()
+                    if c == ord('q'):
+                        break
+            finally:
+                stdscr.erase()
+                curses.nocbreak()
+                curses.echo()
+                curses.endwin()
         else:
             for label, passphrase in self.passphrases.items():
                 if self.scriptableIO:


### PR DESCRIPTION
Pressing C-c when the ncurses screen is up can completely mess up the
terminal display afterwards. By cleaning up the ncurses environment in
any case after the loop is done we ensure that the terminal keeps
functioning properly.